### PR TITLE
SendTopFragmentでアドレスのペースト、一括削除できるように変更

### DIFF
--- a/app/src/main/java/wacode/yamada/yuki/nempaymentapp/extentions/ContextExtentions.kt
+++ b/app/src/main/java/wacode/yamada/yuki/nempaymentapp/extentions/ContextExtentions.kt
@@ -1,8 +1,10 @@
 package wacode.yamada.yuki.nempaymentapp.extentions
 
+import android.content.ClipboardManager
 import android.content.Context
 import android.support.v4.content.ContextCompat
 import android.widget.Toast
+import wacode.yamada.yuki.nempaymentapp.R
 
 fun Context.showToast(textString: String) = Toast.makeText(this, textString, Toast.LENGTH_SHORT).show()
 fun Context.showToast(textResId: Int) = this.showToast(this.getString(textResId))
@@ -10,5 +12,16 @@ fun Context.showToast(textResId: Int) = this.showToast(this.getString(textResId)
 fun Context.getColor(colorResourceId: Int) = ContextCompat.getColor(this, colorResourceId)
 
 fun Context.checkPermission(permission: String) = ContextCompat.checkSelfPermission(this, permission)
+
+fun Context.pasteFromClipBoard(): String {
+    val clipboardManager = this.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+
+    clipboardManager.primaryClip?.let {
+        return it.getItemAt(0).text.toString()
+    } ?: run {
+        this.showToast(R.string.com_paste_error)
+        return ""
+    }
+}
 
 

--- a/app/src/main/java/wacode/yamada/yuki/nempaymentapp/view/fragment/top/SendTopFragment.kt
+++ b/app/src/main/java/wacode/yamada/yuki/nempaymentapp/view/fragment/top/SendTopFragment.kt
@@ -1,7 +1,5 @@
 package wacode.yamada.yuki.nempaymentapp.view.fragment.top
 
-import android.content.ClipboardManager
-import android.content.Context
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.view.View
@@ -13,6 +11,7 @@ import kotlinx.coroutines.experimental.async
 import org.jetbrains.anko.coroutines.experimental.bg
 import wacode.yamada.yuki.nempaymentapp.R
 import wacode.yamada.yuki.nempaymentapp.extentions.isNotTextEmptyObservable
+import wacode.yamada.yuki.nempaymentapp.extentions.pasteFromClipBoard
 import wacode.yamada.yuki.nempaymentapp.extentions.remove
 import wacode.yamada.yuki.nempaymentapp.extentions.showToast
 import wacode.yamada.yuki.nempaymentapp.helper.PinCodeHelper
@@ -48,7 +47,7 @@ class SendTopFragment : BaseFragment() {
         }
 
         clipButton.setOnClickListener {
-            pasteAddress()
+            addressEditText.setText(context.pasteFromClipBoard())
         }
 
         clearButton.setOnClickListener {
@@ -66,16 +65,6 @@ class SendTopFragment : BaseFragment() {
                         clearButton.visibility = View.GONE
                     }
                 }
-    }
-
-    private fun pasteAddress() {
-        val clipboardManager = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-
-        clipboardManager.primaryClip?.let {
-            addressEditText.setText(it.getItemAt(0).text)
-        } ?: run {
-            context.showToast(R.string.com_paste_error)
-        }
     }
 
     fun putQRScanItems(paymentQREntity: PaymentQREntity) {

--- a/app/src/main/res/layout/fragment_send_top.xml
+++ b/app/src/main/res/layout/fragment_send_top.xml
@@ -60,8 +60,8 @@
 
                 <ImageView
                     android:id="@+id/clearButton"
-                    android:layout_width="55px"
-                    android:layout_height="55px"
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
                     android:layout_gravity="center"
                     android:foreground="?selectableItemBackground"
                     android:src="@mipmap/icon_close_circle"

--- a/app/src/main/res/layout/fragment_send_top.xml
+++ b/app/src/main/res/layout/fragment_send_top.xml
@@ -42,14 +42,15 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
+                android:layout_marginLeft="@dimen/space_normal"
+                android:layout_marginRight="16dp"
                 android:orientation="horizontal">
 
                 <EditText
                     android:id="@+id/addressEditText"
                     android:layout_width="0dp"
                     android:layout_height="match_parent"
-                    android:layout_marginLeft="@dimen/space_normal"
-                    android:layout_marginRight="@dimen/space_normal"
+                    android:layout_marginRight="@dimen/space_small"
                     android:layout_weight="1"
                     android:background="#00000000"
                     android:hint="@string/send_top_fragment_hint"
@@ -58,12 +59,23 @@
                     android:textSize="14sp" />
 
                 <ImageView
+                    android:id="@+id/clearButton"
+                    android:layout_width="55px"
+                    android:layout_height="55px"
+                    android:layout_gravity="center"
+                    android:foreground="?selectableItemBackground"
+                    android:src="@mipmap/icon_close_circle"
+                    android:visibility="gone" />
+
+                <ImageView
+                    android:id="@+id/clipButton"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
-                    android:layout_marginRight="16dp"
-                    android:src="@mipmap/icon_addresbook"
-                    android:visibility="gone" />
+                    android:foreground="?selectableItemBackground"
+                    android:src="@mipmap/icon_clipboard"
+                    android:visibility="visible" />
+
             </LinearLayout>
         </android.support.v7.widget.CardView>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="com_jpy_uppercase">JPY</string>
     <string name="com_jp_yen">円</string>
     <string name="com_copied">クリップボードにコピーしました</string>
+    <string name="com_paste_error">貼り付けできませんでした</string>
     <string name="com_message">Message</string>
     <string name="com_mosaic">Mosaic</string>
     <string name="com_prefix_plus">+</string>


### PR DESCRIPTION
### ISSUE
#22 

### 概要
- SendTopFragmentのTextBoxの中身が空の場合、ペーストアイコンが表示され、クリックするとクリップボードにあるものを入りつけることができる
- SendTopFragmentのTextBoxの中身が1文字以上入っている場合、クリアアイコンが表示され、クリックするとTextBoxの中身を一括削除できる
