### PR TITLE
Splashのdispose忘れの修正

### DIFF
--- a/app/src/main/java/wacode/yamada/yuki/nempaymentapp/utils/NemCommons.kt
+++ b/app/src/main/java/wacode/yamada/yuki/nempaymentapp/utils/NemCommons.kt
@@ -35,17 +35,19 @@ object NemCommons {
 
     fun getAccountTransfersIncoming(address: String) =
             getClient().accountTransfersIncoming(address)
+                    .subscribeOn(Schedulers.newThread())
 
     fun getAccountTransfersOutgoing(address: String) =
             getClient().accountTransfersOutgoing(address)
+                    .subscribeOn(Schedulers.newThread())
 
     fun getAccountUnconfirmedTransactions(address: String) =
             getClient().accountUnconfirmedTransactions(address)
+                    .subscribeOn(Schedulers.newThread())
 
     fun getAccountInfoFromPublicKey(publicKey: String) =
             getClient().accountGetFromPublicKey(publicKey)
                     .subscribeOn(Schedulers.newThread())
-                    .observeOn(AndroidSchedulers.mainThread())
 
     fun getAccountMosaicOwned(publicKey: String) =
             getClient().accountMosaicOwned(publicKey)

--- a/app/src/main/java/wacode/yamada/yuki/nempaymentapp/view/adapter/TransactionAdapter.kt
+++ b/app/src/main/java/wacode/yamada/yuki/nempaymentapp/view/adapter/TransactionAdapter.kt
@@ -48,6 +48,7 @@ class TransactionAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>(), Tran
         transactionList.add(transactionEntity)
         addDate(transactionEntity.date)
         Collections.sort(transactionList, DateComparator())
+        notifyDataSetChanged()
     }
 
     fun clearItems() {

--- a/app/src/main/java/wacode/yamada/yuki/nempaymentapp/view/fragment/BaseFragment.kt
+++ b/app/src/main/java/wacode/yamada/yuki/nempaymentapp/view/fragment/BaseFragment.kt
@@ -6,15 +6,12 @@ import android.support.v4.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import io.reactivex.disposables.CompositeDisposable
-import io.reactivex.disposables.Disposable
 import wacode.yamada.yuki.nempaymentapp.view.activity.BaseFragmentActivity
 import wacode.yamada.yuki.nempaymentapp.view.dialog.LoadingDialogFragment
 
 
 abstract class BaseFragment : Fragment() {
     private var loadingDialog: LoadingDialogFragment? = null
-    private val compositeDisposable = CompositeDisposable()
 
     abstract fun layoutRes(): Int
 
@@ -46,26 +43,8 @@ abstract class BaseFragment : Fragment() {
         }
     }
 
-    override fun onDetach() {
-        super.onDetach()
-        hideProgress()
-        unSubscribe()
-    }
-
     protected fun finish() {
         activity.finish()
-    }
-
-    protected fun addDispose(disposable: Disposable) {
-        if (!compositeDisposable.isDisposed) {
-            compositeDisposable.add(disposable)
-        }
-    }
-
-    private fun unSubscribe() {
-        if (!compositeDisposable.isDisposed) {
-            compositeDisposable.dispose()
-        }
     }
 
     @NonNull

--- a/app/src/main/java/wacode/yamada/yuki/nempaymentapp/view/fragment/BaseFragment.kt
+++ b/app/src/main/java/wacode/yamada/yuki/nempaymentapp/view/fragment/BaseFragment.kt
@@ -6,12 +6,16 @@ import android.support.v4.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.disposables.Disposable
 import wacode.yamada.yuki.nempaymentapp.view.activity.BaseFragmentActivity
 import wacode.yamada.yuki.nempaymentapp.view.dialog.LoadingDialogFragment
 
 
 abstract class BaseFragment : Fragment() {
     private var loadingDialog: LoadingDialogFragment? = null
+    private val compositeDisposable = CompositeDisposable()
+
     abstract fun layoutRes(): Int
 
     override fun onCreateView(inflater: LayoutInflater?, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -45,10 +49,23 @@ abstract class BaseFragment : Fragment() {
     override fun onDetach() {
         super.onDetach()
         hideProgress()
+        unSubscribe()
     }
 
     protected fun finish() {
         activity.finish()
+    }
+
+    protected fun addDispose(disposable: Disposable) {
+        if (!compositeDisposable.isDisposed) {
+            compositeDisposable.add(disposable)
+        }
+    }
+
+    private fun unSubscribe() {
+        if (!compositeDisposable.isDisposed) {
+            compositeDisposable.dispose()
+        }
     }
 
     @NonNull

--- a/app/src/main/java/wacode/yamada/yuki/nempaymentapp/view/fragment/SplashFragment.kt
+++ b/app/src/main/java/wacode/yamada/yuki/nempaymentapp/view/fragment/SplashFragment.kt
@@ -20,7 +20,7 @@ class SplashFragment : BaseFragment() {
     override fun onViewCreated(view: View?, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        ActiveNodeHelper.auto(context)
+        val dispose = ActiveNodeHelper.auto(context)
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({
                     if (AppLockPreference.isAvailable(context)) {
@@ -37,6 +37,7 @@ class SplashFragment : BaseFragment() {
                     Toast.makeText(context, R.string.splash_node_select_error, Toast.LENGTH_LONG).show()
                     finishSplash()
                 })
+        addDispose(dispose)
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {

--- a/app/src/main/java/wacode/yamada/yuki/nempaymentapp/view/fragment/SplashFragment.kt
+++ b/app/src/main/java/wacode/yamada/yuki/nempaymentapp/view/fragment/SplashFragment.kt
@@ -7,7 +7,6 @@ import android.view.View
 import android.widget.Toast
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
-import io.reactivex.disposables.Disposable
 import wacode.yamada.yuki.nempaymentapp.R
 import wacode.yamada.yuki.nempaymentapp.helper.ActiveNodeHelper
 import wacode.yamada.yuki.nempaymentapp.preference.AppLockPreference
@@ -41,7 +40,12 @@ class SplashFragment : BaseFragment() {
                     ActiveNodeHelper.saveNodeType(context, NodeType.ALICE2)
                     Toast.makeText(context, R.string.splash_node_select_error, Toast.LENGTH_LONG).show()
                     finishSplash()
-                }).let { addDispose(it) }
+                }).let { compositeDisposable.add(it) }
+    }
+
+    override fun onPause() {
+        super.onPause()
+        compositeDisposable.clear()
     }
 
     override fun onDetach() {
@@ -57,12 +61,6 @@ class SplashFragment : BaseFragment() {
                     finishSplash()
                 }
             }
-        }
-    }
-
-    private fun addDispose(disposable: Disposable) {
-        if (!compositeDisposable.isDisposed) {
-            compositeDisposable.add(disposable)
         }
     }
 

--- a/app/src/main/java/wacode/yamada/yuki/nempaymentapp/view/fragment/TransactionListFragment.kt
+++ b/app/src/main/java/wacode/yamada/yuki/nempaymentapp/view/fragment/TransactionListFragment.kt
@@ -6,14 +6,8 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.View
 import com.ryuta46.nemkotlin.model.AccountMetaDataPair
-import com.ryuta46.nemkotlin.model.TransactionMetaDataPair
-import com.ryuta46.nemkotlin.model.UnconfirmedTransactionMetaDataPair
 import io.reactivex.Observable
-import io.reactivex.Single
 import io.reactivex.android.schedulers.AndroidSchedulers
-import io.reactivex.disposables.CompositeDisposable
-import io.reactivex.functions.Function3
-import io.reactivex.schedulers.Schedulers
 import kotlinx.android.synthetic.main.fragment_transaction_list.*
 import wacode.yamada.yuki.nempaymentapp.R
 import wacode.yamada.yuki.nempaymentapp.extentions.toDisplayAddress
@@ -29,7 +23,6 @@ import wacode.yamada.yuki.nempaymentapp.view.adapter.TransactionAdapter
 class TransactionListFragment : BaseFragment() {
 
     private val adapter = TransactionAdapter()
-    private val compositeDisposable = CompositeDisposable()
 
     override fun layoutRes() = R.layout.fragment_transaction_list
 
@@ -84,70 +77,49 @@ class TransactionListFragment : BaseFragment() {
         val address = wallet.address
 
         val accountTransfersIncoming = NemCommons.getAccountTransfersIncoming(address)
-                .singleOrError()
+                .flatMap { Observable.fromIterable(it) }
+                .map { TransactionAppConverter.convert(TransactionType.INCOMING, it) }
 
         val accountTransfersOutgoing = NemCommons.getAccountTransfersOutgoing(address)
-                .singleOrError()
+                .flatMap { Observable.fromIterable(it) }
+                .map { TransactionAppConverter.convert(TransactionType.OUTGOING, it) }
 
         val accountUnconfirmedTransactions = NemCommons.getAccountUnconfirmedTransactions(address)
-                .singleOrError()
+                .flatMap { Observable.fromIterable(it) }
+                .map { TransactionAppConverter.convert(TransactionType.UNCONFIRMED, it) }
 
-        compositeDisposable.add(
-                Single.zip(
-                        accountTransfersIncoming,
-                        accountTransfersOutgoing,
-                        accountUnconfirmedTransactions,
-                        Function3<List<TransactionMetaDataPair>, List<TransactionMetaDataPair>, List<UnconfirmedTransactionMetaDataPair>, List<TransactionAppEntity>> { incoming, outgoing, unconfirmed ->
-                            val list = Observable.fromIterable(incoming)
-                                    .map { TransactionAppConverter.convert(TransactionType.INCOMING, it) }
-                                    .toList()
-                                    .blockingGet()
-
-                            list.addAll(Observable.fromIterable(outgoing)
-                                    .map { TransactionAppConverter.convert(TransactionType.OUTGOING, it) }
-                                    .toList()
-                                    .blockingGet())
-
-                            list.addAll(Observable.fromIterable(unconfirmed)
-                                    .map { TransactionAppConverter.convert(TransactionType.UNCONFIRMED, it) }
-                                    .toList()
-                                    .blockingGet())
-
-                            list
-                        })
-                        .subscribeOn(Schedulers.newThread())
-                        .observeOn(AndroidSchedulers.mainThread())
-                        .subscribe({
-                            if (it.isEmpty()) {
-                                hideProgress()
-                                transactionEmptyView.visibility = View.VISIBLE
-                            } else {
-                                transactionEmptyView.visibility = View.GONE
-                                fetchSenderAddress(it)
-                            }
-                        }, {
-                            commonErrorHandling(it)
-                        })
-        )
-    }
-
-    private fun fetchSenderAddress(list: List<TransactionAppEntity>) {
-        compositeDisposable.add(
-                Observable.fromIterable(list)
-                        .subscribe({ response ->
-                            NemCommons.getAccountInfoFromPublicKey(response.signer!!)
-                                    .subscribe({ account ->
-                                        response.senderAddress = convertSenderAddress(response, account)
-                                        adapter.addItem(response)
-                                        adapter.notifyDataSetChanged()
-                                        hideProgress()
-                                    }, {
-                                        commonErrorHandling(it)
-                                    })
-                        }, {
-                            commonErrorHandling(it)
-                        })
-        )
+        val singleObservable = Observable.merge(
+                accountTransfersIncoming,
+                accountTransfersOutgoing,
+                accountUnconfirmedTransactions)
+                .toList()
+                .flatMapObservable {
+                    if (it.isEmpty()) {
+                        throw IllegalArgumentException(EXCEPTION_LIST_EMPTY)
+                    } else {
+                        return@flatMapObservable Observable.fromIterable(it)
+                                .flatMap { transactionAppEntity ->
+                                    NemCommons.getAccountInfoFromPublicKey(transactionAppEntity.signer!!)
+                                            .map { account ->
+                                                transactionAppEntity.senderAddress = convertSenderAddress(transactionAppEntity, account)
+                                                return@map transactionAppEntity
+                                            }
+                                }
+                    }
+                }
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe({ it ->
+                    hideProgress()
+                    transactionEmptyView.visibility = View.GONE
+                    adapter.addItem(it)
+                }, {
+                    hideProgress()
+                    if ((it as IllegalArgumentException).message == EXCEPTION_LIST_EMPTY) {
+                        transactionEmptyView.visibility = View.VISIBLE
+                    }
+                    it.printStackTrace()
+                })
+        addDispose(singleObservable)
     }
 
     private fun convertSenderAddress(item: TransactionAppEntity, account: AccountMetaDataPair): String? {
@@ -162,22 +134,13 @@ class TransactionListFragment : BaseFragment() {
         }
     }
 
-    private fun commonErrorHandling(e: Throwable) {
-        hideProgress()
-        e.printStackTrace()
-    }
-
     private val wallet by lazy {
         arguments.getSerializable(KEY_WALLET_MODEL) as Wallet
     }
 
-    override fun onDestroy() {
-        super.onDestroy()
-        compositeDisposable.clear()
-    }
-
     companion object {
         private const val KEY_WALLET_MODEL = "key_wallet_model"
+        private const val EXCEPTION_LIST_EMPTY = "list is empty"
 
         fun newInstance(wallet: Wallet): TransactionListFragment {
             val fragment = TransactionListFragment()

--- a/app/src/main/java/wacode/yamada/yuki/nempaymentapp/view/fragment/TransactionListFragment.kt
+++ b/app/src/main/java/wacode/yamada/yuki/nempaymentapp/view/fragment/TransactionListFragment.kt
@@ -9,7 +9,6 @@ import com.ryuta46.nemkotlin.model.AccountMetaDataPair
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
-import io.reactivex.disposables.Disposable
 import kotlinx.android.synthetic.main.fragment_transaction_list.*
 import wacode.yamada.yuki.nempaymentapp.R
 import wacode.yamada.yuki.nempaymentapp.extentions.toDisplayAddress
@@ -39,6 +38,11 @@ class TransactionListFragment : BaseFragment() {
         if (adapter.itemCount == adapter.HEADER_SIZE) {
             addAllTransaction()
         }
+    }
+
+    override fun onPause() {
+        super.onPause()
+        compositeDisposable.clear()
     }
 
     override fun onDetach() {
@@ -126,13 +130,7 @@ class TransactionListFragment : BaseFragment() {
                         transactionEmptyView.visibility = View.VISIBLE
                     }
                     it.printStackTrace()
-                }).let { addDispose(it) }
-    }
-
-    private fun addDispose(disposable: Disposable) {
-        if (!compositeDisposable.isDisposed) {
-            compositeDisposable.add(disposable)
-        }
+                }).let { compositeDisposable.add(it) }
     }
 
     private fun unSubscribe() {


### PR DESCRIPTION
### 概要
- Crashlyticsに`Splash`と`TransactionList`のDispose忘れによるクラッシュレポートがたくさん上がっていたので、その二つを修正
- ついでにTransactionを取得するロジックのチューニング