### PR TITLE
フレンド登録周りのデザイン修正

### DIFF
--- a/app/src/main/java/wacode/yamada/yuki/nempaymentapp/view/activity/CreateAddressBookActivity.kt
+++ b/app/src/main/java/wacode/yamada/yuki/nempaymentapp/view/activity/CreateAddressBookActivity.kt
@@ -154,7 +154,7 @@ class CreateAddressBookActivity : BaseActivity() {
             val walletList = createFriendWalletFragment.walletList
             val friendInfo = createFriendInfoFragment.getAndCheckFriendInfo()
 
-            if (friendInfo != null && walletList.isNotEmpty()) {
+            if (friendInfo != null) {
                 val uri = circleImageView.tag?.let { it as String } ?: run { "" }
                 friendInfo.iconPath = uri
 

--- a/app/src/main/java/wacode/yamada/yuki/nempaymentapp/view/activity/CreateAddressBookActivity.kt
+++ b/app/src/main/java/wacode/yamada/yuki/nempaymentapp/view/activity/CreateAddressBookActivity.kt
@@ -114,8 +114,8 @@ class CreateAddressBookActivity : BaseActivity() {
 
     private fun setupViewPager() {
         val list = ArrayList<BaseFragment>()
-        list.add(CreateFriendWalletFragment.newInstance())
         list.add(CreateFriendInfoFragment.newInstance())
+        list.add(CreateFriendWalletFragment.newInstance())
 
         val adapter = SimpleViewPagerAdapter(this, list, supportFragmentManager)
         createAddressBookViewPager.adapter = adapter

--- a/app/src/main/java/wacode/yamada/yuki/nempaymentapp/view/fragment/CreateFriendInfoFragment.kt
+++ b/app/src/main/java/wacode/yamada/yuki/nempaymentapp/view/fragment/CreateFriendInfoFragment.kt
@@ -36,7 +36,7 @@ class CreateFriendInfoFragment : BaseFragment() {
     }
 
     companion object {
-        const val PAGE_POSITION = 1
+        const val PAGE_POSITION = 0
 
         fun newInstance(): CreateFriendInfoFragment {
             val fragment = CreateFriendInfoFragment()

--- a/app/src/main/java/wacode/yamada/yuki/nempaymentapp/view/fragment/CreateFriendWalletFragment.kt
+++ b/app/src/main/java/wacode/yamada/yuki/nempaymentapp/view/fragment/CreateFriendWalletFragment.kt
@@ -37,7 +37,7 @@ class CreateFriendWalletFragment : BaseFragment() {
     }
 
     companion object {
-        const val PAGE_POSITION = 0
+        const val PAGE_POSITION = 1
 
         fun newInstance(): CreateFriendWalletFragment {
             val fragment = CreateFriendWalletFragment()

--- a/app/src/main/res/layout/activity_address_book.xml
+++ b/app/src/main/res/layout/activity_address_book.xml
@@ -146,6 +146,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@id/friendNameTextView"
+                    android:layout_centerHorizontal="true"
                     android:textColor="@color/textGray"
                     android:textSize="12sp"
                     tools:text="みょうじ なまえ" />

--- a/app/src/main/res/layout/activity_address_book_list.xml
+++ b/app/src/main/res/layout/activity_address_book_list.xml
@@ -70,7 +70,7 @@
         app:layout_constraintRight_toRightOf="parent"
         app:leftSrc="@drawable/icon_transaction_check"
         app:leftText="@string/com_select"
-        app:rightSrc="@mipmap/icon_plus"
+        app:rightSrc="@mipmap/icon_plus2"
         app:rightText="@string/com_add" />
 
     <wacode.yamada.yuki.nempaymentapp.view.custom_view.RaccoonSingleMaterialButton

--- a/app/src/main/res/layout/activity_create_address_book.xml
+++ b/app/src/main/res/layout/activity_create_address_book.xml
@@ -171,7 +171,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|center"
-        android:visibility="gone"
+        android:visibility="visible"
         app:src="@mipmap/icon_transaction_check"
         app:text="@string/com_enter" />
 
@@ -180,7 +180,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|center"
-        android:visibility="visible"
+        android:visibility="gone"
         app:leftSrc="@drawable/ic_add_black_24dp"
         app:leftText="@string/com_add"
         app:rightSrc="@mipmap/icon_transaction_check"

--- a/app/src/main/res/layout/fragment_friend_info.xml
+++ b/app/src/main/res/layout/fragment_friend_info.xml
@@ -22,6 +22,7 @@
                 android:id="@+id/nameEditText"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:backgroundTint="@color/hintGray"
                 android:inputType="text"
                 android:maxLines="1" />
         </com.google.android.material.textfield.TextInputLayout>
@@ -39,6 +40,7 @@
                 android:id="@+id/nameRubyEdiText"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:backgroundTint="@color/hintGray"
                 android:inputType="text"
                 android:maxLines="1" />
         </com.google.android.material.textfield.TextInputLayout>
@@ -55,6 +57,7 @@
                 android:id="@+id/phoneNumberEditText"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:backgroundTint="@color/hintGray"
                 android:inputType="number"
                 android:maxLines="1" />
         </com.google.android.material.textfield.TextInputLayout>
@@ -71,6 +74,7 @@
                 android:id="@+id/mailAddressEditText"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:backgroundTint="@color/hintGray"
                 android:inputType="textEmailAddress"
                 android:maxLines="1" />
         </com.google.android.material.textfield.TextInputLayout>

--- a/app/src/main/res/layout/view_raccoon_double_material_button.xml
+++ b/app/src/main/res/layout/view_raccoon_double_material_button.xml
@@ -15,6 +15,7 @@
         android:backgroundTint="@android:color/white"
         android:clickable="false"
         android:contentDescription="@null"
+        android:elevation="8dp"
         app:cornerRadius="24sp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
@@ -23,89 +24,94 @@
 
     <View
         android:id="@+id/leftRootView"
-        android:layout_width="60dp"
+        android:layout_width="0dp"
         android:layout_height="30dp"
-        android:background="?selectableItemBackground"
-        android:clickable="true"
-        android:elevation="20dp"
+        android:elevation="8dp"
         app:layout_constraintBottom_toBottomOf="@id/defaultMaterialButton"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.4"
         app:layout_constraintLeft_toLeftOf="@id/defaultMaterialButton"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintRight_toLeftOf="@id/rightRootView"
         app:layout_constraintTop_toTopOf="@id/defaultMaterialButton" />
 
-    <ImageView
-        android:id="@+id/leftImageView"
-        android:layout_width="20dp"
-        android:layout_height="20dp"
-        android:layout_marginTop="6dp"
-        android:contentDescription="@null"
-        android:elevation="8dp"
-        android:padding="2dp"
-        android:tint="@color/colorDarkWhite"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.4"
-        app:layout_constraintLeft_toLeftOf="@id/defaultMaterialButton"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@id/defaultMaterialButton"
-        tools:src="@drawable/ic_check_black_24dp" />
-
-    <TextView
-        android:id="@+id/leftTextView"
+    <android.support.constraint.ConstraintLayout
+        android:id="@+id/leftContainer"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="8dp"
+        android:layout_height="0dp"
+        android:layout_marginRight="@dimen/space_normal_half"
         android:elevation="8dp"
-        android:textColor="@color/colorDarkWhite"
-        android:textSize="12sp"
-        app:layout_constraintBottom_toBottomOf="@id/defaultMaterialButton"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.4"
-        app:layout_constraintLeft_toLeftOf="@id/defaultMaterialButton"
-        app:layout_constraintStart_toStartOf="parent"
-        tools:text="もしもし" />
+        app:layout_constraintBottom_toBottomOf="@id/leftRootView"
+        app:layout_constraintRight_toRightOf="@id/leftRootView"
+        app:layout_constraintTop_toTopOf="@id/leftRootView">
 
-    <ImageView
-        android:id="@+id/rightImageView"
-        android:layout_width="20dp"
-        android:layout_height="20dp"
-        android:layout_marginTop="6dp"
-        android:contentDescription="@null"
-        android:elevation="8dp"
-        android:padding="2dp"
-        android:tint="@color/colorDarkWhite"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.6"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@id/defaultMaterialButton"
-        tools:src="@drawable/ic_check_black_24dp" />
+        <ImageView
+            android:id="@+id/leftImageView"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:padding="2dp"
+            android:tint="@color/colorDarkWhite"
+            app:layout_constraintLeft_toLeftOf="@id/leftContainer"
+            app:layout_constraintRight_toRightOf="@id/leftContainer"
+            app:layout_constraintTop_toTopOf="@id/leftContainer"
+            tools:src="@drawable/ic_check_black_24dp" />
+
+        <TextView
+            android:id="@+id/leftTextView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:textColor="@color/colorDarkWhite"
+            android:textSize="12sp"
+            app:layout_constraintBottom_toBottomOf="@id/leftContainer"
+            app:layout_constraintLeft_toLeftOf="@id/leftContainer"
+            app:layout_constraintRight_toRightOf="@id/leftContainer"
+            app:layout_constraintTop_toBottomOf="@id/leftImageView"
+            tools:text="もしもし" />
+    </android.support.constraint.ConstraintLayout>
 
     <View
         android:id="@+id/rightRootView"
-        android:layout_width="60dp"
+        android:layout_width="0dp"
         android:layout_height="30dp"
-        android:background="?selectableItemBackground"
-        android:clickable="true"
-        android:elevation="20dp"
+        android:elevation="8dp"
         app:layout_constraintBottom_toBottomOf="@id/defaultMaterialButton"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.6"
-        app:layout_constraintLeft_toLeftOf="@id/defaultMaterialButton"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintLeft_toRightOf="@id/leftRootView"
+        app:layout_constraintRight_toRightOf="@id/defaultMaterialButton"
         app:layout_constraintTop_toTopOf="@id/defaultMaterialButton" />
 
-    <TextView
-        android:id="@+id/rightTextView"
+    <android.support.constraint.ConstraintLayout
+        android:id="@+id/rightContainer"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="8dp"
+        android:layout_height="0dp"
+        android:layout_marginLeft="@dimen/space_normal_half"
         android:elevation="8dp"
-        android:textColor="@color/colorDarkWhite"
-        android:textSize="12sp"
-        app:layout_constraintBottom_toBottomOf="@id/defaultMaterialButton"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.6"
-        app:layout_constraintStart_toStartOf="parent"
-        tools:text="アルギニン" />
+        app:layout_constraintBottom_toBottomOf="@id/rightRootView"
+        app:layout_constraintLeft_toRightOf="@id/leftRootView"
+        app:layout_constraintTop_toTopOf="@id/rightRootView">
+
+        <ImageView
+            android:id="@+id/rightImageView"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:contentDescription="@null"
+            android:padding="2dp"
+            android:tint="@color/colorDarkWhite"
+            app:layout_constraintLeft_toLeftOf="@id/rightContainer"
+            app:layout_constraintRight_toRightOf="@id/rightContainer"
+            app:layout_constraintTop_toTopOf="@id/rightContainer"
+            tools:src="@drawable/ic_check_black_24dp" />
+
+        <TextView
+            android:id="@+id/rightTextView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:textColor="@color/colorDarkWhite"
+            android:textSize="12sp"
+            app:layout_constraintBottom_toBottomOf="@id/rightContainer"
+            app:layout_constraintLeft_toLeftOf="@id/rightContainer"
+            app:layout_constraintRight_toRightOf="@id/rightContainer"
+            app:layout_constraintTop_toBottomOf="@id/rightImageView"
+            tools:text="アルギニン" />
+
+    </android.support.constraint.ConstraintLayout>
+
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -573,7 +573,7 @@
     <!-- CreateFriend -->
     <string name="create_friend_address_title">プロフィール</string>
     <string name="create_friend_wallet_title">ウォレット</string>
-    <string name="create_friend_input_error_message">名前とウォレットを登録してください</string>
+    <string name="create_friend_input_error_message">プロフィールを登録してください</string>
     <string name="create_friend_address_cooperation_title">連携</string>
     <string name="create_friend_address_change_icon_title">アイコンを変更</string>
     <string name="create_friend_address_input_title">プロフィールを入力しましょう！</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -512,7 +512,7 @@
 
     <!-- WalletBackupActivity -->
     <string name="wallet_backup_activity_title">バックアップ</string>
-    
+
     <!-- MyAddressProfileActivity -->
     <string name="my_address_profile_activity_empty_title">リストは、まだ空っぽです</string>
     <string name="my_address_profile_activity_empty_description">ここは、自分のウォレットを整理する場所です。 ボタンからウォレットを追加したり、プロフィールタブから 自分のデータを入力できるよ。</string>
@@ -571,7 +571,7 @@
     <string name="address_book_list_sort_second">よく送る順</string>
 
     <!-- CreateFriend -->
-    <string name="create_friend_address_title">連絡先</string>
+    <string name="create_friend_address_title">プロフィール</string>
     <string name="create_friend_wallet_title">ウォレット</string>
     <string name="create_friend_input_error_message">名前とウォレットを登録してください</string>
     <string name="create_friend_address_cooperation_title">連携</string>
@@ -583,7 +583,7 @@
 
     <!-- AddressBook -->
     <string name="address_book_friend_wallet_title">ウォレット</string>
-    <string name="address_book_friend_info_title">連絡先</string>
+    <string name="address_book_friend_info_title">プロフィール</string>
 
     <!--Dialog-->
     <string name="dialog_update_forward_title">アプリのアップデートがあります</string>


### PR DESCRIPTION
### 概要
- リムさんのデザインチェック修正
    -  huaweiボタン「選択」「追加」などが2つ以上並んでいるときのスペースが狭く誤動作を誘発する→スペースを開けて誤操作をなくしたい。
    - 一覧から入った個人ページでの名前とふりがなを左揃え→中央揃えにしたい
    - フレンドリスト個人ページの名前下タブの「ウォレット」の右側が「連絡先」と「プロフィール」でバラバラなので「プロフィール」に統一したい。
    - フレンドを新規登録する際に、最初に飛ぶタブを「ウォレット」から「プロフィール」に変更したい。
    - フレンドを新規登録する際に、 プロフィールを必須、ウォレット登録を任意にしたい。
    - 非アクティブでないテキストフィールドはグレーになっていてほしい。
- 以上６つのデザイン修正 