### PR TITLE
送金最終確認画面で小数点以下が四捨五入されてしまっている不具合を修正

### DIFF
--- a/app/src/main/java/wacode/yamada/yuki/nempaymentapp/rest/item/SendMosaicItem.kt
+++ b/app/src/main/java/wacode/yamada/yuki/nempaymentapp/rest/item/SendMosaicItem.kt
@@ -19,7 +19,21 @@ class SendMosaicItem(mosaicItem: MosaicItem, val amount: Double) : Serializable 
     fun mosaicName() = name
     fun nameSpace() = namespaceId
     private fun getFullName() = "$namespaceId:$name"
-    fun getFormattedAmount() = NumberFormat.getNumberInstance().format(amount) + " " + getFullName()
+    fun getFormattedAmount(): String {
+        val numberFormat = NumberFormat.getNumberInstance()
+        val count = if ((amount % 1)  == 0.0) 0 else countUpAmountDecimalPoint(amount.toString())
+        numberFormat.minimumFractionDigits = count
+        return numberFormat.format(amount) + " " + getFullName()
+    }
+
+    private fun countUpAmountDecimalPoint(amountString: String): Int {
+        if (amountString.matches(Regex("^.*\\.0+$"))) {
+            return 0
+        }
+
+        val index = amountString.indexOf(".")
+        return amountString.substring(index + 1).length
+    }
 
     companion object {
         fun createNEMXEMItem(amount: Double) = SendMosaicItem(MosaicItem(MosaicAppEntity(MosaicIdAppEntity("nem", "xem"), 0)), amount)


### PR DESCRIPTION
#84 

タイトルの通り

テストケース
- 小数点無し
- 小数点あり　ノットマックス（小数点以下７桁以下）
- 小数点あり　マックス　小数点以下７桁